### PR TITLE
WIP: otel arena

### DIFF
--- a/modules/grpc/common/CMakeLists.txt
+++ b/modules/grpc/common/CMakeLists.txt
@@ -20,7 +20,8 @@ set(GRPC_COMMON_CPP_SOURCES
   grpc-grammar-internal.h
   grpc-grammar-internal.c
   grpc-source-worker.hpp
-  grpc-source-worker.cpp)
+  grpc-source-worker.cpp
+  protobuf-arena.hpp)
 
 set(GRPC_COMMON_GRAMMAR ${PROJECT_SOURCE_DIR}/modules/grpc/common/grpc-grammar.ym PARENT_SCOPE)
 

--- a/modules/grpc/common/Makefile.am
+++ b/modules/grpc/common/Makefile.am
@@ -32,7 +32,8 @@ modules_grpc_common_libgrpc_common_la_SOURCES = \
   modules/grpc/common/grpc-source.hpp \
   modules/grpc/common/grpc-source.cpp \
   modules/grpc/common/grpc-source-worker.hpp \
-  modules/grpc/common/grpc-source-worker.cpp
+  modules/grpc/common/grpc-source-worker.cpp \
+  modules/grpc/common/protobuf-arena.hpp
 
 modules_grpc_common_libgrpc_common_la_CXXFLAGS = \
   $(AM_CXXFLAGS) \

--- a/modules/grpc/common/grpc-dest-worker.cpp
+++ b/modules/grpc/common/grpc-dest-worker.cpp
@@ -32,13 +32,18 @@
 #include "scratch-buffers.h"
 #include "compat/cpp-end.h"
 
+
+constexpr const auto ARENA_SIZE = 32*1024*1024;
+
 using namespace syslogng::grpc;
 
 /* C++ Implementations */
 
 DestWorker::DestWorker(GrpcDestWorker *s)
   : super(s),
-    owner(*(reinterpret_cast<GrpcDestDriver *>(s->super.owner))->cpp)
+    owner(*(reinterpret_cast<GrpcDestDriver *>(s->super.owner))->cpp),
+    arena_buffer(ARENA_SIZE),
+    arena{arena_buffer.data(), arena_buffer.size()}
 {
 }
 

--- a/modules/grpc/common/grpc-dest-worker.hpp
+++ b/modules/grpc/common/grpc-dest-worker.hpp
@@ -28,6 +28,7 @@
 #include <grpcpp/client_context.h>
 #include <grpcpp/create_channel.h>
 #include <grpcpp/security/credentials.h>
+#include <google/protobuf/arena.h>
 
 #include "grpc-dest.hpp"
 
@@ -60,6 +61,7 @@ protected:
   GrpcDestWorker *super;
   DestDriver &owner;
   bool connected;
+  google::protobuf::Arena arena;
   std::shared_ptr<::grpc::Channel> channel;
 };
 

--- a/modules/grpc/common/grpc-dest-worker.hpp
+++ b/modules/grpc/common/grpc-dest-worker.hpp
@@ -61,6 +61,7 @@ protected:
   GrpcDestWorker *super;
   DestDriver &owner;
   bool connected;
+  std::vector<char> arena_buffer;
   google::protobuf::Arena arena;
   std::shared_ptr<::grpc::Channel> channel;
 };

--- a/modules/grpc/common/protobuf-arena.hpp
+++ b/modules/grpc/common/protobuf-arena.hpp
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2026 Axoflow
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef PROTOBUF_ARENA_HPP
+#define PROTOBUF_ARENA_HPP
+
+#include <google/protobuf/arena.h>
+#include <google/protobuf/stubs/common.h>
+
+namespace syslogng {
+namespace grpc {
+
+template <typename T>
+T *arena_create_message(google::protobuf::Arena *arena)
+{
+#if GOOGLE_PROTOBUF_VERSION >= 5026000
+  return google::protobuf::Arena::Create<T>(arena);
+#else
+  return google::protobuf::Arena::CreateMessage<T>(arena);
+#endif
+}
+
+}
+}
+
+#endif

--- a/modules/grpc/otel/otel-dest-worker.cpp
+++ b/modules/grpc/otel/otel-dest-worker.cpp
@@ -528,12 +528,6 @@ DestWorker::flush(LogThreadedFlushMode mode)
 
 exit:
   client_context.reset();
-  logs_service_request->Clear();
-  metrics_service_request->Clear();
-  trace_service_request->Clear();
-  trace_service_response->Clear();
-  metrics_service_response->Clear();
-  logs_service_response->Clear();
   fallback_msg_scope_logs = nullptr;
 
   int64_t before_reset_allocated = arena.SpaceAllocated();

--- a/modules/grpc/otel/otel-dest-worker.cpp
+++ b/modules/grpc/otel/otel-dest-worker.cpp
@@ -87,6 +87,8 @@ DestWorker::DestWorker(GrpcDestWorker *s)
     spans_current_batch_bytes(0),
     formatter(s->super.owner->super.super.super.cfg)
 {
+  g_assert(&arena);
+  g_assert(logs_service_request->GetArena());
 }
 
 void
@@ -527,6 +529,8 @@ DestWorker::flush(LogThreadedFlushMode mode)
     }
 
 exit:
+  msg_trace("before dest clear",  evt_tag_int("allocated", arena.SpaceAllocated()), evt_tag_int("used",
+            arena.SpaceUsed()));
   client_context.reset();
   fallback_msg_scope_logs = nullptr;
 

--- a/modules/grpc/otel/otel-dest-worker.cpp
+++ b/modules/grpc/otel/otel-dest-worker.cpp
@@ -21,6 +21,8 @@
  *
  */
 
+#include "common/protobuf-arena.hpp"
+
 #include <grpc/grpc.h>
 #include <grpcpp/channel.h>
 #include <grpcpp/client_context.h>
@@ -74,8 +76,14 @@ DestWorker::connect()
 
 DestWorker::DestWorker(GrpcDestWorker *s)
   : syslogng::grpc::DestWorker(s),
+    logs_service_request(syslogng::grpc::arena_create_message<ExportLogsServiceRequest>(&arena)),
+    logs_service_response(syslogng::grpc::arena_create_message<ExportLogsServiceResponse>(&arena)),
     logs_current_batch_bytes(0),
+    metrics_service_request(syslogng::grpc::arena_create_message<ExportMetricsServiceRequest>(&arena)),
+    metrics_service_response(syslogng::grpc::arena_create_message<ExportMetricsServiceResponse>(&arena)),
     metrics_current_batch_bytes(0),
+    trace_service_request(syslogng::grpc::arena_create_message<ExportTraceServiceRequest>(&arena)),
+    trace_service_response(syslogng::grpc::arena_create_message<ExportTraceServiceResponse>(&arena)),
     spans_current_batch_bytes(0),
     formatter(s->super.owner->super.super.super.cfg)
 {
@@ -107,9 +115,9 @@ DestWorker::lookup_scope_logs(LogMessage *msg)
   get_metadata_for_current_msg(msg);
 
   ResourceLogs *resource_logs = nullptr;
-  for (int i = 0; i < logs_service_request.resource_logs_size(); i++)
+  for (int i = 0; i < logs_service_request->resource_logs_size(); i++)
     {
-      ResourceLogs *possible_resource_logs = logs_service_request.mutable_resource_logs(i);
+      ResourceLogs *possible_resource_logs = logs_service_request->mutable_resource_logs(i);
       if (MessageDifferencer::Equals(possible_resource_logs->resource(), current_msg_metadata.resource) &&
           possible_resource_logs->schema_url() == current_msg_metadata.resource_schema_url)
         {
@@ -119,7 +127,7 @@ DestWorker::lookup_scope_logs(LogMessage *msg)
     }
   if (!resource_logs)
     {
-      resource_logs = logs_service_request.add_resource_logs();
+      resource_logs = logs_service_request->add_resource_logs();
       resource_logs->mutable_resource()->CopyFrom(current_msg_metadata.resource);
       resource_logs->set_schema_url(current_msg_metadata.resource_schema_url);
     }
@@ -157,9 +165,9 @@ DestWorker::lookup_fallback_scope_logs(LogMessage *msg)
     return fallback_msg_scope_logs;
 
   ResourceLogs *resource_logs = nullptr;
-  for (int i = 0; i < logs_service_request.resource_logs_size(); i++)
+  for (int i = 0; i < logs_service_request->resource_logs_size(); i++)
     {
-      ResourceLogs *possible_resource_logs = logs_service_request.mutable_resource_logs(i);
+      ResourceLogs *possible_resource_logs = logs_service_request->mutable_resource_logs(i);
       if (MessageDifferencer::Equals(possible_resource_logs->resource(), current_msg_metadata.resource) &&
           possible_resource_logs->schema_url() == current_msg_metadata.resource_schema_url)
         {
@@ -169,7 +177,7 @@ DestWorker::lookup_fallback_scope_logs(LogMessage *msg)
     }
   if (!resource_logs)
     {
-      resource_logs = logs_service_request.add_resource_logs();
+      resource_logs = logs_service_request->add_resource_logs();
     }
 
   fallback_msg_scope_logs = resource_logs->add_scope_logs();
@@ -183,9 +191,9 @@ DestWorker::lookup_scope_metrics(LogMessage *msg)
   get_metadata_for_current_msg(msg);
 
   ResourceMetrics *resource_metrics = nullptr;
-  for (int i = 0; i < metrics_service_request.resource_metrics_size(); i++)
+  for (int i = 0; i < metrics_service_request->resource_metrics_size(); i++)
     {
-      ResourceMetrics *possible_resource_metrics = metrics_service_request.mutable_resource_metrics(i);
+      ResourceMetrics *possible_resource_metrics = metrics_service_request->mutable_resource_metrics(i);
       if (MessageDifferencer::Equals(possible_resource_metrics->resource(), current_msg_metadata.resource) &&
           possible_resource_metrics->schema_url() == current_msg_metadata.resource_schema_url)
         {
@@ -195,7 +203,7 @@ DestWorker::lookup_scope_metrics(LogMessage *msg)
     }
   if (!resource_metrics)
     {
-      resource_metrics = metrics_service_request.add_resource_metrics();
+      resource_metrics = metrics_service_request->add_resource_metrics();
       resource_metrics->mutable_resource()->CopyFrom(current_msg_metadata.resource);
       resource_metrics->set_schema_url(current_msg_metadata.resource_schema_url);
     }
@@ -227,9 +235,9 @@ DestWorker::lookup_scope_spans(LogMessage *msg)
   get_metadata_for_current_msg(msg);
 
   ResourceSpans *resource_spans = nullptr;
-  for (int i = 0; i < trace_service_request.resource_spans_size(); i++)
+  for (int i = 0; i < trace_service_request->resource_spans_size(); i++)
     {
-      ResourceSpans *possible_resource_spans = trace_service_request.mutable_resource_spans(i);
+      ResourceSpans *possible_resource_spans = trace_service_request->mutable_resource_spans(i);
       if (MessageDifferencer::Equals(possible_resource_spans->resource(), current_msg_metadata.resource) &&
           possible_resource_spans->schema_url() == current_msg_metadata.resource_schema_url)
         {
@@ -239,7 +247,7 @@ DestWorker::lookup_scope_spans(LogMessage *msg)
     }
   if (!resource_spans)
     {
-      resource_spans = trace_service_request.add_resource_spans();
+      resource_spans = trace_service_request->add_resource_spans();
       resource_spans->mutable_resource()->CopyFrom(current_msg_metadata.resource);
       resource_spans->set_schema_url(current_msg_metadata.resource_schema_url);
     }
@@ -432,9 +440,8 @@ permanent_error:
 LogThreadedResult
 DestWorker::flush_log_records()
 {
-  logs_service_response.Clear();
-  ::grpc::Status status = logs_service_stub->Export(client_context.get(), logs_service_request,
-                                                    &logs_service_response);
+  ::grpc::Status status = logs_service_stub->Export(client_context.get(), *logs_service_request,
+                                                    logs_service_response);
   owner.metrics.insert_grpc_request_stats(status);
 
   LogThreadedResult result;
@@ -453,9 +460,8 @@ DestWorker::flush_log_records()
 LogThreadedResult
 DestWorker::flush_metrics()
 {
-  metrics_service_response.Clear();
-  ::grpc::Status status = metrics_service_stub->Export(client_context.get(), metrics_service_request,
-                                                       &metrics_service_response);
+  ::grpc::Status status = metrics_service_stub->Export(client_context.get(), *metrics_service_request,
+                                                       metrics_service_response);
   owner.metrics.insert_grpc_request_stats(status);
 
   LogThreadedResult result;
@@ -474,9 +480,8 @@ DestWorker::flush_metrics()
 LogThreadedResult
 DestWorker::flush_spans()
 {
-  trace_service_response.Clear();
-  ::grpc::Status status = trace_service_stub->Export(client_context.get(), trace_service_request,
-                                                     &trace_service_response);
+  ::grpc::Status status = trace_service_stub->Export(client_context.get(), *trace_service_request,
+                                                     trace_service_response);
   owner.metrics.insert_grpc_request_stats(status);
 
   LogThreadedResult result;
@@ -500,21 +505,21 @@ DestWorker::flush(LogThreadedFlushMode mode)
   if (mode == LTF_FLUSH_EXPEDITE)
     return LTR_RETRY;
 
-  if (logs_service_request.resource_logs_size() > 0)
+  if (logs_service_request->resource_logs_size() > 0)
     {
       result = flush_log_records();
       if (result != LTR_SUCCESS)
         goto exit;
     }
 
-  if (metrics_service_request.resource_metrics_size() > 0)
+  if (metrics_service_request->resource_metrics_size() > 0)
     {
       result = flush_metrics();
       if (result != LTR_SUCCESS)
         goto exit;
     }
 
-  if (trace_service_request.resource_spans_size() > 0)
+  if (trace_service_request->resource_spans_size() > 0)
     {
       result = flush_spans();
       if (result != LTR_SUCCESS)
@@ -523,10 +528,34 @@ DestWorker::flush(LogThreadedFlushMode mode)
 
 exit:
   client_context.reset();
-  logs_service_request.Clear();
-  metrics_service_request.Clear();
-  trace_service_request.Clear();
+  logs_service_request->Clear();
+  metrics_service_request->Clear();
+  trace_service_request->Clear();
+  trace_service_response->Clear();
+  metrics_service_response->Clear();
+  logs_service_response->Clear();
   fallback_msg_scope_logs = nullptr;
+
+  int64_t before_reset_allocated = arena.SpaceAllocated();
+  int64_t before_reset_used = arena.SpaceUsed();
+  int64_t reset = arena.Reset();
+  int64_t after_reset_allocated = arena.SpaceAllocated();
+  int64_t after_reset_used = arena.SpaceUsed();
+
+  msg_trace("dest reset",
+            evt_tag_int("before_reset_allocated", before_reset_allocated),
+            evt_tag_int("before_reset_used", before_reset_used),
+            evt_tag_int("reset", reset),
+            evt_tag_int("after_reset_allocated", after_reset_allocated),
+            evt_tag_int("after_reset_used", after_reset_used)
+           );
+
+  logs_service_request = syslogng::grpc::arena_create_message<ExportLogsServiceRequest>(&arena);
+  logs_service_response = syslogng::grpc::arena_create_message<ExportLogsServiceResponse>(&arena);
+  metrics_service_request = syslogng::grpc::arena_create_message<ExportMetricsServiceRequest>(&arena);
+  metrics_service_response = syslogng::grpc::arena_create_message<ExportMetricsServiceResponse>(&arena);
+  trace_service_request = syslogng::grpc::arena_create_message<ExportTraceServiceRequest>(&arena);
+  trace_service_response = syslogng::grpc::arena_create_message<ExportTraceServiceResponse>(&arena);
 
   logs_current_batch_bytes = metrics_current_batch_bytes = spans_current_batch_bytes = 0;
 

--- a/modules/grpc/otel/otel-dest-worker.hpp
+++ b/modules/grpc/otel/otel-dest-worker.hpp
@@ -90,14 +90,14 @@ protected:
   std::unique_ptr<MetricsService::Stub> metrics_service_stub;
   std::unique_ptr<TraceService::Stub> trace_service_stub;
 
-  ExportLogsServiceRequest logs_service_request;
-  ExportLogsServiceResponse logs_service_response;
+  ExportLogsServiceRequest *logs_service_request;
+  ExportLogsServiceResponse *logs_service_response;
   size_t logs_current_batch_bytes;
-  ExportMetricsServiceRequest metrics_service_request;
-  ExportMetricsServiceResponse metrics_service_response;
+  ExportMetricsServiceRequest *metrics_service_request;
+  ExportMetricsServiceResponse *metrics_service_response;
   size_t metrics_current_batch_bytes;
-  ExportTraceServiceRequest trace_service_request;
-  ExportTraceServiceResponse trace_service_response;
+  ExportTraceServiceRequest *trace_service_request;
+  ExportTraceServiceResponse *trace_service_response;
   size_t spans_current_batch_bytes;
 
   ProtobufFormatter formatter;

--- a/modules/grpc/otel/otel-source-services.hpp
+++ b/modules/grpc/otel/otel-source-services.hpp
@@ -58,7 +58,7 @@ public:
 
 public:
   AsyncServiceCall(SourceWorker &worker_, S *service_, ::grpc::ServerCompletionQueue *cq_)
-    : worker(worker_), service(service_), responder(&ctx), cq(cq_), status(PROCESS)
+    : worker(worker_), service(service_), responder(&ctx), cq(cq_), status(PROCESS_REQUEST)
   {
     service->RequestExport(&ctx, &request, &responder, cq, cq, this);
   }
@@ -73,7 +73,7 @@ private:
   ::grpc::ServerCompletionQueue *cq;
   ::grpc::ServerContext ctx;
 
-  enum CallStatus { PROCESS, FINISH };
+  enum CallStatus { PROCESS_REQUEST, SEND_RESPONSE };
   CallStatus status;
 };
 
@@ -84,7 +84,7 @@ private:
 template <> void
 syslogng::grpc::otel::TraceServiceCall::Proceed(bool ok)
 {
-  if (status == FINISH || !ok)
+  if (status == SEND_RESPONSE || !ok)
     {
       delete this;
       new TraceServiceCall(worker, service, cq);
@@ -135,14 +135,14 @@ syslogng::grpc::otel::TraceServiceCall::Proceed(bool ok)
   if (msgs_in_fetch_round != 0)
     log_threaded_source_worker_close_batch(&worker.super->super);
 
-  status = FINISH;
+  status = SEND_RESPONSE;
   responder.Finish(response, response_status, this);
 }
 
 template <> void
 syslogng::grpc::otel::LogsServiceCall::Proceed(bool ok)
 {
-  if (status == FINISH || !ok)
+  if (status == SEND_RESPONSE || !ok)
     {
       delete this;
       new LogsServiceCall(worker, service, cq);
@@ -200,14 +200,14 @@ syslogng::grpc::otel::LogsServiceCall::Proceed(bool ok)
   if (msgs_in_fetch_round != 0)
     log_threaded_source_worker_close_batch(&worker.super->super);
 
-  status = FINISH;
+  status = SEND_RESPONSE;
   responder.Finish(response, response_status, this);
 }
 
 template <> void
 syslogng::grpc::otel::MetricsServiceCall::Proceed(bool ok)
 {
-  if (status == FINISH || !ok)
+  if (status == SEND_RESPONSE || !ok)
     {
       delete this;
       new MetricsServiceCall(worker, service, cq);
@@ -258,7 +258,7 @@ syslogng::grpc::otel::MetricsServiceCall::Proceed(bool ok)
   if (msgs_in_fetch_round != 0)
     log_threaded_source_worker_close_batch(&worker.super->super);
 
-  status = FINISH;
+  status = SEND_RESPONSE;
   responder.Finish(response, response_status, this);
 }
 

--- a/modules/grpc/otel/otel-source-services.hpp
+++ b/modules/grpc/otel/otel-source-services.hpp
@@ -87,10 +87,10 @@ syslogng::grpc::otel::TraceServiceCall::Proceed(bool ok)
   if (status == FINISH || !ok)
     {
       delete this;
+      new TraceServiceCall(worker, service, cq);
       return;
     }
 
-  new TraceServiceCall(worker, service, cq);
 
   ::grpc::Status response_status = ::grpc::Status::OK;
 
@@ -145,10 +145,9 @@ syslogng::grpc::otel::LogsServiceCall::Proceed(bool ok)
   if (status == FINISH || !ok)
     {
       delete this;
+      new LogsServiceCall(worker, service, cq);
       return;
     }
-
-  new LogsServiceCall(worker, service, cq);
 
   ::grpc::Status response_status = ::grpc::Status::OK;
 
@@ -211,10 +210,10 @@ syslogng::grpc::otel::MetricsServiceCall::Proceed(bool ok)
   if (status == FINISH || !ok)
     {
       delete this;
+      new MetricsServiceCall(worker, service, cq);
       return;
     }
 
-  new MetricsServiceCall(worker, service, cq);
 
   ::grpc::Status response_status = ::grpc::Status::OK;
 

--- a/modules/grpc/otel/syslog-ng-otlp-dest-worker.cpp
+++ b/modules/grpc/otel/syslog-ng-otlp-dest-worker.cpp
@@ -28,14 +28,14 @@ using namespace opentelemetry::proto::logs::v1;
 ScopeLogs *
 SyslogNgDestWorker::lookup_scope_logs(LogMessage *msg)
 {
-  if (logs_service_request.resource_logs_size() > 0)
-    return logs_service_request.mutable_resource_logs(0)->mutable_scope_logs(0);
+  if (logs_service_request->resource_logs_size() > 0)
+    return logs_service_request->mutable_resource_logs(0)->mutable_scope_logs(0);
 
   clear_current_msg_metadata();
   formatter.get_metadata_for_syslog_ng(current_msg_metadata.resource, current_msg_metadata.resource_schema_url,
                                        current_msg_metadata.scope, current_msg_metadata.scope_schema_url);
 
-  ResourceLogs *resource_logs = logs_service_request.add_resource_logs();
+  ResourceLogs *resource_logs = logs_service_request->add_resource_logs();
   resource_logs->mutable_resource()->CopyFrom(current_msg_metadata.resource);
   resource_logs->set_schema_url(current_msg_metadata.resource_schema_url);
 

--- a/modules/grpc/otel/syslog-ng-otlp-dest-worker.cpp
+++ b/modules/grpc/otel/syslog-ng-otlp-dest-worker.cpp
@@ -28,6 +28,8 @@ using namespace opentelemetry::proto::logs::v1;
 ScopeLogs *
 SyslogNgDestWorker::lookup_scope_logs(LogMessage *msg)
 {
+  g_assert(logs_service_request->GetArena());
+  g_assert(logs_service_request->GetArena() == &arena);
   if (logs_service_request->resource_logs_size() > 0)
     return logs_service_request->mutable_resource_logs(0)->mutable_scope_logs(0);
 
@@ -36,10 +38,14 @@ SyslogNgDestWorker::lookup_scope_logs(LogMessage *msg)
                                        current_msg_metadata.scope, current_msg_metadata.scope_schema_url);
 
   ResourceLogs *resource_logs = logs_service_request->add_resource_logs();
+  g_assert(resource_logs->GetArena());
+  g_assert(resource_logs->GetArena() == &arena);
   resource_logs->mutable_resource()->CopyFrom(current_msg_metadata.resource);
   resource_logs->set_schema_url(current_msg_metadata.resource_schema_url);
 
   ScopeLogs *scope_logs = resource_logs->add_scope_logs();
+  g_assert(scope_logs->GetArena());
+  g_assert(scope_logs->GetArena() == &arena);
   scope_logs->mutable_scope()->CopyFrom(current_msg_metadata.scope);
   scope_logs->set_schema_url(current_msg_metadata.scope_schema_url);
 
@@ -51,6 +57,7 @@ SyslogNgDestWorker::insert(LogMessage *msg)
 {
   ScopeLogs *scope_logs = lookup_scope_logs(msg);
   LogRecord *log_record = scope_logs->add_log_records();
+  g_assert(log_record->GetArena() == &arena);
   formatter.format_syslog_ng(msg, *log_record);
 
   size_t log_record_bytes = log_record->ByteSizeLong();


### PR DESCRIPTION
This is done in order to make sure that new ServiceCall objects
are only created once their predecessor's destructor is called.

Signed-off-by: Szilard Parrag <szilard.parrag@axoflow.com><!--
Thank you for contributing to AxoSyslog. Please make sure you:
- Read our Contribution guideline: https://github.com/axoflow/axosyslog/blob/main/CONTRIBUTING.md
- Checked that tests pass (including stylechecks: `make style-check`)
- Wrote a news file, if applicable: https://github.com/axoflow/axosyslog/tree/main/news
-->


<!--
PR description
In the description, please explain the problem your pull request intends to solve, and a give general overview of the implementation.
For more information, see: https://github.com/axoflow/axosyslog/blob/main/CONTRIBUTING.md#pr-description
-->
This is done in order to make sure that new ServiceCall objects
are only created once their predecessor's destructor is called.

Signed-off-by: Szilard Parrag <szilard.parrag@axoflow.com>