### PR TITLE
WIP: smart arena

### DIFF
--- a/modules/grpc/bigquery/bigquery-worker.cpp
+++ b/modules/grpc/bigquery/bigquery-worker.cpp
@@ -46,7 +46,9 @@ using syslogng::grpc::bigquery::DestinationDriver;
 using google::protobuf::FieldDescriptor;
 
 DestinationWorker::DestinationWorker(GrpcDestWorker *s)
-  : syslogng::grpc::DestWorker(s)
+  : syslogng::grpc::DestWorker(s),
+    current_batch(arena.CreateMessage<google::cloud::bigquery::storage::v1::AppendRowsRequest>()),
+    append_rows_response(arena.CreateMessage<google::cloud::bigquery::storage::v1::AppendRowsResponse>())
 {
   std::stringstream table_name;
   DestinationDriver *owner_ = this->get_owner();
@@ -141,12 +143,15 @@ DestinationWorker::prepare_batch()
 {
   this->batch_size = 0;
   this->current_batch_bytes = 0;
-  this->current_batch = google::cloud::bigquery::storage::v1::AppendRowsRequest{};
 
-  this->current_batch.set_write_stream(write_stream.name());
-  this->current_batch.set_trace_id("syslog-ng-bigquery");
+  this->arena.Reset();
+  this->current_batch = arena.CreateMessage<google::cloud::bigquery::storage::v1::AppendRowsRequest>();
+  this->append_rows_response = arena.CreateMessage<google::cloud::bigquery::storage::v1::AppendRowsResponse>();
+
+  this->current_batch->set_write_stream(write_stream.name());
+  this->current_batch->set_trace_id("syslog-ng-bigquery");
   google::cloud::bigquery::storage::v1::AppendRowsRequest_ProtoData *proto_rows =
-    this->current_batch.mutable_proto_rows();
+    this->current_batch->mutable_proto_rows();
   google::cloud::bigquery::storage::v1::ProtoSchema *schema = proto_rows->mutable_writer_schema();
   this->get_owner()->log_message_protobuf_formatter.get_schema_descriptor().CopyTo(schema->mutable_proto_descriptor());
 }
@@ -164,7 +169,7 @@ DestinationWorker::insert(LogMessage *msg)
   std::string serialized_row;
   size_t row_bytes = 0;
 
-  google::cloud::bigquery::storage::v1::ProtoRows *rows = this->current_batch.mutable_proto_rows()->mutable_rows();
+  google::cloud::bigquery::storage::v1::ProtoRows *rows = this->current_batch->mutable_proto_rows()->mutable_rows();
 
   google::protobuf::Message *message = nullptr;
 
@@ -244,40 +249,39 @@ DestinationWorker::flush(LogThreadedFlushMode mode)
     return LTR_SUCCESS;
 
   LogThreadedResult result;
-  google::cloud::bigquery::storage::v1::AppendRowsResponse append_rows_response;
 
-  if (!this->batch_writer->Write(current_batch))
+  if (!this->batch_writer->Write(*this->current_batch))
     {
       msg_error("Error writing BigQuery batch", log_pipe_location_tag((LogPipe *) this->super->super.owner));
       result = LTR_ERROR;
       goto error;
     }
 
-  if (!this->batch_writer->Read(&append_rows_response))
+  if (!this->batch_writer->Read(this->append_rows_response))
     {
       msg_error("Error reading BigQuery batch response", log_pipe_location_tag((LogPipe *) this->super->super.owner));
       result = LTR_ERROR;
       goto error;
     }
 
-  if (this->get_owner()->handle_response(_append_rows_response_get_status(append_rows_response), &result))
+  if (this->get_owner()->handle_response(_append_rows_response_get_status(*this->append_rows_response), &result))
     {
       if (result == LTR_SUCCESS)
         goto success;
       goto error;
     }
 
-  if (append_rows_response.has_error() && append_rows_response.error().code() != ::grpc::StatusCode::ALREADY_EXISTS)
+  if (this->append_rows_response->has_error() && this->append_rows_response->error().code() != ::grpc::StatusCode::ALREADY_EXISTS)
     {
       msg_error("Error in BigQuery batch",
-                evt_tag_str("error", append_rows_response.error().message().c_str()),
-                evt_tag_int("code", append_rows_response.error().code()),
+                evt_tag_str("error", this->append_rows_response->error().message().c_str()),
+                evt_tag_int("code", this->append_rows_response->error().code()),
                 log_pipe_location_tag((LogPipe *) this->super->super.owner));
 
       result = LTR_ERROR;
 
-      if (append_rows_response.row_errors_size() != 0)
-        result = handle_row_errors(append_rows_response);
+      if (this->append_rows_response->row_errors_size() != 0)
+        result = handle_row_errors(*this->append_rows_response);
 
       goto error;
     }
@@ -290,7 +294,7 @@ success:
   result = LTR_SUCCESS;
 
 error:
-  this->get_owner()->metrics.insert_grpc_request_stats(_append_rows_response_get_status(append_rows_response));
+  this->get_owner()->metrics.insert_grpc_request_stats(_append_rows_response_get_status(*this->append_rows_response));
   this->prepare_batch();
   return result;
 }

--- a/modules/grpc/bigquery/bigquery-worker.hpp
+++ b/modules/grpc/bigquery/bigquery-worker.hpp
@@ -83,7 +83,8 @@ private:
       google::cloud::bigquery::storage::v1::AppendRowsResponse>> batch_writer;
 
   /* batch state */
-  google::cloud::bigquery::storage::v1::AppendRowsRequest current_batch;
+  google::cloud::bigquery::storage::v1::AppendRowsRequest *current_batch;
+  google::cloud::bigquery::storage::v1::AppendRowsResponse *append_rows_response;
   size_t batch_size = 0;
   size_t current_batch_bytes = 0;
 };

--- a/modules/grpc/clickhouse/clickhouse-dest-worker.cpp
+++ b/modules/grpc/clickhouse/clickhouse-dest-worker.cpp
@@ -61,7 +61,9 @@ DestWorker::connect()
 }
 
 DestWorker::DestWorker(GrpcDestWorker *s)
-  : syslogng::grpc::DestWorker(s)
+  : syslogng::grpc::DestWorker(s),
+    query_info(arena.CreateMessage<::clickhouse::grpc::QueryInfo>()),
+    query_result(arena.CreateMessage<::clickhouse::grpc::Result>())
 {
 }
 
@@ -167,15 +169,15 @@ drop:
 }
 
 void
-DestWorker::prepare_query_info(::clickhouse::grpc::QueryInfo &query_info)
+DestWorker::prepare_query_info()
 {
   DestDriver *owner_ = this->get_owner();
 
-  query_info.set_database(owner_->get_database());
-  query_info.set_user_name(owner_->get_user());
-  query_info.set_password(owner_->get_password());
-  query_info.set_query(owner_->get_query());
-  query_info.set_input_data(this->query_data.str());
+  this->query_info->set_database(owner_->get_database());
+  this->query_info->set_user_name(owner_->get_user());
+  this->query_info->set_password(owner_->get_password());
+  this->query_info->set_query(owner_->get_query());
+  this->query_info->set_input_data(this->query_data.str());
 }
 
 static LogThreadedResult
@@ -239,6 +241,10 @@ DestWorker::prepare_batch()
   this->batch_size = 0;
   this->current_batch_bytes = 0;
   this->client_context.reset();
+
+  this->arena.Reset();
+  this->query_info = arena.CreateMessage<::clickhouse::grpc::QueryInfo>();
+  this->query_result = arena.CreateMessage<::clickhouse::grpc::Result>();
 }
 
 LogThreadedResult
@@ -247,12 +253,9 @@ DestWorker::flush(LogThreadedFlushMode mode)
   if (this->batch_size == 0)
     return LTR_SUCCESS;
 
-  ::clickhouse::grpc::QueryInfo query_info;
-  ::clickhouse::grpc::Result query_result;
+  this->prepare_query_info();
 
-  this->prepare_query_info(query_info);
-
-  ::grpc::Status status = this->stub->ExecuteQuery(this->client_context.get(), query_info, &query_result);
+  ::grpc::Status status = this->stub->ExecuteQuery(this->client_context.get(), *this->query_info, this->query_result);
 
   LogThreadedResult result;
   if (owner.handle_response(status, &result))
@@ -266,9 +269,9 @@ DestWorker::flush(LogThreadedFlushMode mode)
   if (result != LTR_SUCCESS)
     goto error;
 
-  if (query_result.has_exception())
+  if (this->query_result->has_exception())
     {
-      const ::clickhouse::grpc::Exception &exception = query_result.exception();
+      const ::clickhouse::grpc::Exception &exception = this->query_result->exception();
       ErrorAction action = classify_clickhouse_error((ClickHouseErrorCode)exception.code());
       msg_error("ClickHouse server responded with an exception",
                 evt_tag_int("code", exception.code()),

--- a/modules/grpc/clickhouse/clickhouse-dest-worker.hpp
+++ b/modules/grpc/clickhouse/clickhouse-dest-worker.hpp
@@ -53,13 +53,16 @@ private:
   bool insert_query_data_from_jsonvar(LogMessage *msg);
   bool insert_query_data_from_schema(LogMessage *msg);
   bool should_initiate_flush();
-  void prepare_query_info(::clickhouse::grpc::QueryInfo &query_info);
+  void prepare_query_info();
   void prepare_batch();
   DestDriver *get_owner();
 
 private:
   std::unique_ptr<::clickhouse::grpc::ClickHouse::Stub> stub;
   std::unique_ptr<::grpc::ClientContext> client_context;
+
+  ::clickhouse::grpc::QueryInfo *query_info;
+  ::clickhouse::grpc::Result *query_result;
 
   std::ostringstream query_data;
   size_t batch_size = 0;

--- a/modules/grpc/common/CMakeLists.txt
+++ b/modules/grpc/common/CMakeLists.txt
@@ -20,7 +20,8 @@ set(GRPC_COMMON_CPP_SOURCES
   grpc-grammar-internal.h
   grpc-grammar-internal.c
   grpc-source-worker.hpp
-  grpc-source-worker.cpp)
+  grpc-source-worker.cpp
+  protobuf-arena.hpp)
 
 set(GRPC_COMMON_GRAMMAR ${PROJECT_SOURCE_DIR}/modules/grpc/common/grpc-grammar.ym PARENT_SCOPE)
 

--- a/modules/grpc/common/CMakeLists.txt
+++ b/modules/grpc/common/CMakeLists.txt
@@ -21,7 +21,8 @@ set(GRPC_COMMON_CPP_SOURCES
   grpc-grammar-internal.c
   grpc-source-worker.hpp
   grpc-source-worker.cpp
-  protobuf-arena.hpp)
+  protobuf-arena.hpp
+  protobuf-arena.cpp)
 
 set(GRPC_COMMON_GRAMMAR ${PROJECT_SOURCE_DIR}/modules/grpc/common/grpc-grammar.ym PARENT_SCOPE)
 

--- a/modules/grpc/common/Makefile.am
+++ b/modules/grpc/common/Makefile.am
@@ -33,7 +33,8 @@ modules_grpc_common_libgrpc_common_la_SOURCES = \
   modules/grpc/common/grpc-source.cpp \
   modules/grpc/common/grpc-source-worker.hpp \
   modules/grpc/common/grpc-source-worker.cpp \
-  modules/grpc/common/protobuf-arena.hpp
+  modules/grpc/common/protobuf-arena.hpp \
+  modules/grpc/common/protobuf-arena.cpp
 
 modules_grpc_common_libgrpc_common_la_CXXFLAGS = \
   $(AM_CXXFLAGS) \

--- a/modules/grpc/common/Makefile.am
+++ b/modules/grpc/common/Makefile.am
@@ -32,7 +32,8 @@ modules_grpc_common_libgrpc_common_la_SOURCES = \
   modules/grpc/common/grpc-source.hpp \
   modules/grpc/common/grpc-source.cpp \
   modules/grpc/common/grpc-source-worker.hpp \
-  modules/grpc/common/grpc-source-worker.cpp
+  modules/grpc/common/grpc-source-worker.cpp \
+  modules/grpc/common/protobuf-arena.hpp
 
 modules_grpc_common_libgrpc_common_la_CXXFLAGS = \
   $(AM_CXXFLAGS) \

--- a/modules/grpc/common/grpc-dest-worker.cpp
+++ b/modules/grpc/common/grpc-dest-worker.cpp
@@ -32,6 +32,7 @@
 #include "scratch-buffers.h"
 #include "compat/cpp-end.h"
 
+
 using namespace syslogng::grpc;
 
 /* C++ Implementations */

--- a/modules/grpc/common/grpc-dest-worker.hpp
+++ b/modules/grpc/common/grpc-dest-worker.hpp
@@ -28,6 +28,7 @@
 #include <grpcpp/client_context.h>
 #include <grpcpp/create_channel.h>
 #include <grpcpp/security/credentials.h>
+#include <google/protobuf/arena.h>
 
 #include "grpc-dest.hpp"
 
@@ -60,6 +61,7 @@ protected:
   GrpcDestWorker *super;
   DestDriver &owner;
   bool connected;
+  google::protobuf::Arena arena;
   std::shared_ptr<::grpc::Channel> channel;
 };
 

--- a/modules/grpc/common/grpc-dest-worker.hpp
+++ b/modules/grpc/common/grpc-dest-worker.hpp
@@ -28,9 +28,8 @@
 #include <grpcpp/client_context.h>
 #include <grpcpp/create_channel.h>
 #include <grpcpp/security/credentials.h>
-#include <google/protobuf/arena.h>
-
 #include "grpc-dest.hpp"
+#include "protobuf-arena.hpp"
 
 typedef struct GrpcDestWorker_ GrpcDestWorker;
 
@@ -61,7 +60,7 @@ protected:
   GrpcDestWorker *super;
   DestDriver &owner;
   bool connected;
-  google::protobuf::Arena arena;
+  SmartArena arena;
   std::shared_ptr<::grpc::Channel> channel;
 };
 

--- a/modules/grpc/common/protobuf-arena.cpp
+++ b/modules/grpc/common/protobuf-arena.cpp
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2026 Axoflow
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "protobuf-arena.hpp"
+
+#include <algorithm>
+
+using namespace syslogng::grpc;
+
+SmartArena::SmartArena(size_t initial_size)
+  : arena_buffer(initial_size),
+    arena(std::make_unique<google::protobuf::Arena>(arena_buffer.data(), arena_buffer.size()))
+{}
+
+size_t SmartArena::DefaultInitialSize = 256;
+
+google::protobuf::Arena *
+SmartArena::get()
+{
+  return arena.get();
+}
+
+size_t
+SmartArena::SpaceAllocated()
+{
+  return arena->SpaceAllocated();
+}
+
+size_t
+SmartArena::SpaceUsed()
+{
+  return arena->SpaceUsed();
+}
+
+uint64_t
+SmartArena::Reset()
+{
+  size_t used = arena->SpaceUsed();
+  size_t current_size = arena_buffer.size();
+
+  if (used >= 2 * current_size || used * 2 <= current_size)
+    {
+      size_t new_size = std::max(used, DefaultInitialSize);
+      arena.reset();
+      arena_buffer.resize(new_size);
+      arena = std::make_unique<google::protobuf::Arena>(arena_buffer.data(), arena_buffer.size());
+      return used;
+    }
+
+  return arena->Reset();
+}

--- a/modules/grpc/common/protobuf-arena.hpp
+++ b/modules/grpc/common/protobuf-arena.hpp
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2026 Axoflow
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef PROTOBUF_ARENA_HPP
+#define PROTOBUF_ARENA_HPP
+
+#include <google/protobuf/arena.h>
+#include <google/protobuf/stubs/common.h>
+
+namespace syslogng {
+namespace grpc {
+
+template <typename T>
+T *arena_create_message(google::protobuf::Arena *arena)
+{
+#if GOOGLE_PROTOBUF_VERSION >= 5026000
+  return google::protobuf::Arena::Create<T>(arena);
+#else
+  return google::protobuf::Arena::CreateMessage<T>(arena);
+#endif
+}
+
+}
+}
+
+#endif

--- a/modules/grpc/common/protobuf-arena.hpp
+++ b/modules/grpc/common/protobuf-arena.hpp
@@ -26,18 +26,39 @@
 #include <google/protobuf/arena.h>
 #include <google/protobuf/stubs/common.h>
 
+#include <memory>
+#include <vector>
+
 namespace syslogng {
 namespace grpc {
 
-template <typename T>
-T *arena_create_message(google::protobuf::Arena *arena)
+class SmartArena
 {
+  static size_t DefaultInitialSize;
+
+private:
+  std::vector<char> arena_buffer;
+  std::unique_ptr<google::protobuf::Arena> arena;
+
+public:
+  SmartArena(size_t initial_size = DefaultInitialSize);
+
+  google::protobuf::Arena *get();
+
+  template <typename T>
+  T *CreateMessage()
+  {
 #if GOOGLE_PROTOBUF_VERSION >= 5026000
-  return google::protobuf::Arena::Create<T>(arena);
+    return google::protobuf::Arena::Create<T>(arena.get());
 #else
-  return google::protobuf::Arena::CreateMessage<T>(arena);
+    return google::protobuf::Arena::CreateMessage<T>(arena.get());
 #endif
-}
+  }
+
+  size_t SpaceAllocated();
+  size_t SpaceUsed();
+  uint64_t Reset();
+};
 
 }
 }

--- a/modules/grpc/loki/loki-worker.cpp
+++ b/modules/grpc/loki/loki-worker.cpp
@@ -55,6 +55,13 @@ struct _LokiDestWorker
   DestinationWorker *cpp;
 };
 
+DestinationWorker::DestinationWorker(GrpcDestWorker *s)
+  : syslogng::grpc::DestWorker(s),
+    current_batch(arena.CreateMessage<logproto::PushRequest>()),
+    response(arena.CreateMessage<logproto::PushResponse>())
+{
+}
+
 bool
 DestinationWorker::init()
 {
@@ -92,10 +99,14 @@ DestinationWorker::connect()
 void
 DestinationWorker::prepare_batch()
 {
-  this->current_batch = logproto::PushRequest{};
-  this->current_batch.add_streams();
-  this->current_batch_bytes = 0;
   this->client_context.reset();
+  this->current_batch_bytes = 0;
+
+  this->arena.Reset();
+  this->current_batch = arena.CreateMessage<logproto::PushRequest>();
+  this->response = arena.CreateMessage<logproto::PushResponse>();
+
+  this->current_batch->add_streams();
 }
 
 bool
@@ -108,7 +119,7 @@ void
 DestinationWorker::set_labels(LogMessage *msg)
 {
   DestinationDriver *owner_ = this->get_owner();
-  logproto::StreamAdapter *stream = this->current_batch.mutable_streams(0);
+  logproto::StreamAdapter *stream = this->current_batch->mutable_streams(0);
 
   LogTemplateEvalOptions options = {&owner_->template_options, LTZ_SEND, this->super->super.seq_num, NULL, LM_VT_STRING};
 
@@ -159,7 +170,7 @@ LogThreadedResult
 DestinationWorker::insert(LogMessage *msg)
 {
   DestinationDriver *owner_ = this->get_owner();
-  logproto::StreamAdapter *stream = this->current_batch.mutable_streams(0);
+  logproto::StreamAdapter *stream = this->current_batch->mutable_streams(0);
 
   if (stream->entries_size() == 0)
     this->set_labels(msg);
@@ -205,9 +216,8 @@ DestinationWorker::flush(LogThreadedFlushMode mode)
     return LTR_SUCCESS;
 
   LogThreadedResult result;
-  logproto::PushResponse response{};
 
-  ::grpc::Status status = this->stub->Push(client_context.get(), this->current_batch, &response);
+  ::grpc::Status status = this->stub->Push(client_context.get(), *this->current_batch, this->response);
   this->get_owner()->metrics.insert_grpc_request_stats(status);
 
   if (this->get_owner()->handle_response(status, &result))

--- a/modules/grpc/loki/loki-worker.hpp
+++ b/modules/grpc/loki/loki-worker.hpp
@@ -46,7 +46,7 @@ namespace loki {
 class DestinationWorker final: public syslogng::grpc::DestWorker
 {
 public:
-  DestinationWorker(GrpcDestWorker *s) : syslogng::grpc::DestWorker(s) {};
+  DestinationWorker(GrpcDestWorker *s);
   ~DestinationWorker() {};
 
   LogThreadedResult insert(LogMessage *msg) override;
@@ -67,7 +67,8 @@ private:
 private:
   std::unique_ptr<::grpc::ClientContext> client_context;
   std::unique_ptr<logproto::Pusher::Stub> stub;
-  logproto::PushRequest current_batch;
+  logproto::PushRequest *current_batch;
+  logproto::PushResponse *response;
   size_t current_batch_bytes = 0;
 };
 

--- a/modules/grpc/otel/otel-dest-worker.cpp
+++ b/modules/grpc/otel/otel-dest-worker.cpp
@@ -21,6 +21,8 @@
  *
  */
 
+#include "common/protobuf-arena.hpp"
+
 #include <grpc/grpc.h>
 #include <grpcpp/channel.h>
 #include <grpcpp/client_context.h>
@@ -74,8 +76,14 @@ DestWorker::connect()
 
 DestWorker::DestWorker(GrpcDestWorker *s)
   : syslogng::grpc::DestWorker(s),
+    logs_service_request(syslogng::grpc::arena_create_message<ExportLogsServiceRequest>(&arena)),
+    logs_service_response(syslogng::grpc::arena_create_message<ExportLogsServiceResponse>(&arena)),
     logs_current_batch_bytes(0),
+    metrics_service_request(syslogng::grpc::arena_create_message<ExportMetricsServiceRequest>(&arena)),
+    metrics_service_response(syslogng::grpc::arena_create_message<ExportMetricsServiceResponse>(&arena)),
     metrics_current_batch_bytes(0),
+    trace_service_request(syslogng::grpc::arena_create_message<ExportTraceServiceRequest>(&arena)),
+    trace_service_response(syslogng::grpc::arena_create_message<ExportTraceServiceResponse>(&arena)),
     spans_current_batch_bytes(0),
     formatter(s->super.owner->super.super.super.cfg)
 {
@@ -107,9 +115,9 @@ DestWorker::lookup_scope_logs(LogMessage *msg)
   get_metadata_for_current_msg(msg);
 
   ResourceLogs *resource_logs = nullptr;
-  for (int i = 0; i < logs_service_request.resource_logs_size(); i++)
+  for (int i = 0; i < logs_service_request->resource_logs_size(); i++)
     {
-      ResourceLogs *possible_resource_logs = logs_service_request.mutable_resource_logs(i);
+      ResourceLogs *possible_resource_logs = logs_service_request->mutable_resource_logs(i);
       if (MessageDifferencer::Equals(possible_resource_logs->resource(), current_msg_metadata.resource) &&
           possible_resource_logs->schema_url() == current_msg_metadata.resource_schema_url)
         {
@@ -119,7 +127,7 @@ DestWorker::lookup_scope_logs(LogMessage *msg)
     }
   if (!resource_logs)
     {
-      resource_logs = logs_service_request.add_resource_logs();
+      resource_logs = logs_service_request->add_resource_logs();
       resource_logs->mutable_resource()->CopyFrom(current_msg_metadata.resource);
       resource_logs->set_schema_url(current_msg_metadata.resource_schema_url);
     }
@@ -157,9 +165,9 @@ DestWorker::lookup_fallback_scope_logs(LogMessage *msg)
     return fallback_msg_scope_logs;
 
   ResourceLogs *resource_logs = nullptr;
-  for (int i = 0; i < logs_service_request.resource_logs_size(); i++)
+  for (int i = 0; i < logs_service_request->resource_logs_size(); i++)
     {
-      ResourceLogs *possible_resource_logs = logs_service_request.mutable_resource_logs(i);
+      ResourceLogs *possible_resource_logs = logs_service_request->mutable_resource_logs(i);
       if (MessageDifferencer::Equals(possible_resource_logs->resource(), current_msg_metadata.resource) &&
           possible_resource_logs->schema_url() == current_msg_metadata.resource_schema_url)
         {
@@ -169,7 +177,7 @@ DestWorker::lookup_fallback_scope_logs(LogMessage *msg)
     }
   if (!resource_logs)
     {
-      resource_logs = logs_service_request.add_resource_logs();
+      resource_logs = logs_service_request->add_resource_logs();
     }
 
   fallback_msg_scope_logs = resource_logs->add_scope_logs();
@@ -183,9 +191,9 @@ DestWorker::lookup_scope_metrics(LogMessage *msg)
   get_metadata_for_current_msg(msg);
 
   ResourceMetrics *resource_metrics = nullptr;
-  for (int i = 0; i < metrics_service_request.resource_metrics_size(); i++)
+  for (int i = 0; i < metrics_service_request->resource_metrics_size(); i++)
     {
-      ResourceMetrics *possible_resource_metrics = metrics_service_request.mutable_resource_metrics(i);
+      ResourceMetrics *possible_resource_metrics = metrics_service_request->mutable_resource_metrics(i);
       if (MessageDifferencer::Equals(possible_resource_metrics->resource(), current_msg_metadata.resource) &&
           possible_resource_metrics->schema_url() == current_msg_metadata.resource_schema_url)
         {
@@ -195,7 +203,7 @@ DestWorker::lookup_scope_metrics(LogMessage *msg)
     }
   if (!resource_metrics)
     {
-      resource_metrics = metrics_service_request.add_resource_metrics();
+      resource_metrics = metrics_service_request->add_resource_metrics();
       resource_metrics->mutable_resource()->CopyFrom(current_msg_metadata.resource);
       resource_metrics->set_schema_url(current_msg_metadata.resource_schema_url);
     }
@@ -227,9 +235,9 @@ DestWorker::lookup_scope_spans(LogMessage *msg)
   get_metadata_for_current_msg(msg);
 
   ResourceSpans *resource_spans = nullptr;
-  for (int i = 0; i < trace_service_request.resource_spans_size(); i++)
+  for (int i = 0; i < trace_service_request->resource_spans_size(); i++)
     {
-      ResourceSpans *possible_resource_spans = trace_service_request.mutable_resource_spans(i);
+      ResourceSpans *possible_resource_spans = trace_service_request->mutable_resource_spans(i);
       if (MessageDifferencer::Equals(possible_resource_spans->resource(), current_msg_metadata.resource) &&
           possible_resource_spans->schema_url() == current_msg_metadata.resource_schema_url)
         {
@@ -239,7 +247,7 @@ DestWorker::lookup_scope_spans(LogMessage *msg)
     }
   if (!resource_spans)
     {
-      resource_spans = trace_service_request.add_resource_spans();
+      resource_spans = trace_service_request->add_resource_spans();
       resource_spans->mutable_resource()->CopyFrom(current_msg_metadata.resource);
       resource_spans->set_schema_url(current_msg_metadata.resource_schema_url);
     }
@@ -432,9 +440,8 @@ permanent_error:
 LogThreadedResult
 DestWorker::flush_log_records()
 {
-  logs_service_response.Clear();
-  ::grpc::Status status = logs_service_stub->Export(client_context.get(), logs_service_request,
-                                                    &logs_service_response);
+  ::grpc::Status status = logs_service_stub->Export(client_context.get(), *logs_service_request,
+                                                    logs_service_response);
   owner.metrics.insert_grpc_request_stats(status);
 
   LogThreadedResult result;
@@ -453,9 +460,8 @@ DestWorker::flush_log_records()
 LogThreadedResult
 DestWorker::flush_metrics()
 {
-  metrics_service_response.Clear();
-  ::grpc::Status status = metrics_service_stub->Export(client_context.get(), metrics_service_request,
-                                                       &metrics_service_response);
+  ::grpc::Status status = metrics_service_stub->Export(client_context.get(), *metrics_service_request,
+                                                       metrics_service_response);
   owner.metrics.insert_grpc_request_stats(status);
 
   LogThreadedResult result;
@@ -474,9 +480,8 @@ DestWorker::flush_metrics()
 LogThreadedResult
 DestWorker::flush_spans()
 {
-  trace_service_response.Clear();
-  ::grpc::Status status = trace_service_stub->Export(client_context.get(), trace_service_request,
-                                                     &trace_service_response);
+  ::grpc::Status status = trace_service_stub->Export(client_context.get(), *trace_service_request,
+                                                     trace_service_response);
   owner.metrics.insert_grpc_request_stats(status);
 
   LogThreadedResult result;
@@ -500,21 +505,21 @@ DestWorker::flush(LogThreadedFlushMode mode)
   if (mode == LTF_FLUSH_EXPEDITE)
     return LTR_RETRY;
 
-  if (logs_service_request.resource_logs_size() > 0)
+  if (logs_service_request->resource_logs_size() > 0)
     {
       result = flush_log_records();
       if (result != LTR_SUCCESS)
         goto exit;
     }
 
-  if (metrics_service_request.resource_metrics_size() > 0)
+  if (metrics_service_request->resource_metrics_size() > 0)
     {
       result = flush_metrics();
       if (result != LTR_SUCCESS)
         goto exit;
     }
 
-  if (trace_service_request.resource_spans_size() > 0)
+  if (trace_service_request->resource_spans_size() > 0)
     {
       result = flush_spans();
       if (result != LTR_SUCCESS)
@@ -523,10 +528,16 @@ DestWorker::flush(LogThreadedFlushMode mode)
 
 exit:
   client_context.reset();
-  logs_service_request.Clear();
-  metrics_service_request.Clear();
-  trace_service_request.Clear();
   fallback_msg_scope_logs = nullptr;
+
+  arena.Reset();
+
+  logs_service_request = syslogng::grpc::arena_create_message<ExportLogsServiceRequest>(&arena);
+  logs_service_response = syslogng::grpc::arena_create_message<ExportLogsServiceResponse>(&arena);
+  metrics_service_request = syslogng::grpc::arena_create_message<ExportMetricsServiceRequest>(&arena);
+  metrics_service_response = syslogng::grpc::arena_create_message<ExportMetricsServiceResponse>(&arena);
+  trace_service_request = syslogng::grpc::arena_create_message<ExportTraceServiceRequest>(&arena);
+  trace_service_response = syslogng::grpc::arena_create_message<ExportTraceServiceResponse>(&arena);
 
   logs_current_batch_bytes = metrics_current_batch_bytes = spans_current_batch_bytes = 0;
 

--- a/modules/grpc/otel/otel-dest-worker.cpp
+++ b/modules/grpc/otel/otel-dest-worker.cpp
@@ -21,8 +21,6 @@
  *
  */
 
-#include "common/protobuf-arena.hpp"
-
 #include <grpc/grpc.h>
 #include <grpcpp/channel.h>
 #include <grpcpp/client_context.h>
@@ -76,14 +74,14 @@ DestWorker::connect()
 
 DestWorker::DestWorker(GrpcDestWorker *s)
   : syslogng::grpc::DestWorker(s),
-    logs_service_request(syslogng::grpc::arena_create_message<ExportLogsServiceRequest>(&arena)),
-    logs_service_response(syslogng::grpc::arena_create_message<ExportLogsServiceResponse>(&arena)),
+    logs_service_request(arena.CreateMessage<ExportLogsServiceRequest>()),
+    logs_service_response(arena.CreateMessage<ExportLogsServiceResponse>()),
     logs_current_batch_bytes(0),
-    metrics_service_request(syslogng::grpc::arena_create_message<ExportMetricsServiceRequest>(&arena)),
-    metrics_service_response(syslogng::grpc::arena_create_message<ExportMetricsServiceResponse>(&arena)),
+    metrics_service_request(arena.CreateMessage<ExportMetricsServiceRequest>()),
+    metrics_service_response(arena.CreateMessage<ExportMetricsServiceResponse>()),
     metrics_current_batch_bytes(0),
-    trace_service_request(syslogng::grpc::arena_create_message<ExportTraceServiceRequest>(&arena)),
-    trace_service_response(syslogng::grpc::arena_create_message<ExportTraceServiceResponse>(&arena)),
+    trace_service_request(arena.CreateMessage<ExportTraceServiceRequest>()),
+    trace_service_response(arena.CreateMessage<ExportTraceServiceResponse>()),
     spans_current_batch_bytes(0),
     formatter(s->super.owner->super.super.super.cfg)
 {
@@ -532,12 +530,12 @@ exit:
 
   arena.Reset();
 
-  logs_service_request = syslogng::grpc::arena_create_message<ExportLogsServiceRequest>(&arena);
-  logs_service_response = syslogng::grpc::arena_create_message<ExportLogsServiceResponse>(&arena);
-  metrics_service_request = syslogng::grpc::arena_create_message<ExportMetricsServiceRequest>(&arena);
-  metrics_service_response = syslogng::grpc::arena_create_message<ExportMetricsServiceResponse>(&arena);
-  trace_service_request = syslogng::grpc::arena_create_message<ExportTraceServiceRequest>(&arena);
-  trace_service_response = syslogng::grpc::arena_create_message<ExportTraceServiceResponse>(&arena);
+  logs_service_request = arena.CreateMessage<ExportLogsServiceRequest>();
+  logs_service_response = arena.CreateMessage<ExportLogsServiceResponse>();
+  metrics_service_request = arena.CreateMessage<ExportMetricsServiceRequest>();
+  metrics_service_response = arena.CreateMessage<ExportMetricsServiceResponse>();
+  trace_service_request = arena.CreateMessage<ExportTraceServiceRequest>();
+  trace_service_response = arena.CreateMessage<ExportTraceServiceResponse>();
 
   logs_current_batch_bytes = metrics_current_batch_bytes = spans_current_batch_bytes = 0;
 

--- a/modules/grpc/otel/otel-dest-worker.hpp
+++ b/modules/grpc/otel/otel-dest-worker.hpp
@@ -90,14 +90,14 @@ protected:
   std::unique_ptr<MetricsService::Stub> metrics_service_stub;
   std::unique_ptr<TraceService::Stub> trace_service_stub;
 
-  ExportLogsServiceRequest logs_service_request;
-  ExportLogsServiceResponse logs_service_response;
+  ExportLogsServiceRequest *logs_service_request;
+  ExportLogsServiceResponse *logs_service_response;
   size_t logs_current_batch_bytes;
-  ExportMetricsServiceRequest metrics_service_request;
-  ExportMetricsServiceResponse metrics_service_response;
+  ExportMetricsServiceRequest *metrics_service_request;
+  ExportMetricsServiceResponse *metrics_service_response;
   size_t metrics_current_batch_bytes;
-  ExportTraceServiceRequest trace_service_request;
-  ExportTraceServiceResponse trace_service_response;
+  ExportTraceServiceRequest *trace_service_request;
+  ExportTraceServiceResponse *trace_service_response;
   size_t spans_current_batch_bytes;
 
   ProtobufFormatter formatter;

--- a/modules/grpc/otel/otel-source-services.hpp
+++ b/modules/grpc/otel/otel-source-services.hpp
@@ -58,7 +58,7 @@ public:
 
 public:
   AsyncServiceCall(SourceWorker &worker_, S *service_, ::grpc::ServerCompletionQueue *cq_)
-    : worker(worker_), service(service_), responder(&ctx), cq(cq_), status(PROCESS)
+    : worker(worker_), service(service_), responder(&ctx), cq(cq_), status(PROCESS_REQUEST)
   {
     service->RequestExport(&ctx, &request, &responder, cq, cq, this);
   }
@@ -73,7 +73,7 @@ private:
   ::grpc::ServerCompletionQueue *cq;
   ::grpc::ServerContext ctx;
 
-  enum CallStatus { PROCESS, FINISH };
+  enum CallStatus { PROCESS_REQUEST, SEND_RESPONSE };
   CallStatus status;
 };
 
@@ -84,7 +84,7 @@ private:
 template <> void
 syslogng::grpc::otel::TraceServiceCall::Proceed(bool ok)
 {
-  if (status == FINISH || !ok)
+  if (status == SEND_RESPONSE || !ok)
     {
       new TraceServiceCall(worker, service, cq);
       delete this;
@@ -134,14 +134,14 @@ syslogng::grpc::otel::TraceServiceCall::Proceed(bool ok)
   if (msgs_in_fetch_round != 0)
     log_threaded_source_worker_close_batch(&worker.super->super);
 
-  status = FINISH;
+  status = SEND_RESPONSE;
   responder.Finish(response, response_status, this);
 }
 
 template <> void
 syslogng::grpc::otel::LogsServiceCall::Proceed(bool ok)
 {
-  if (status == FINISH || !ok)
+  if (status == SEND_RESPONSE || !ok)
     {
       new LogsServiceCall(worker, service, cq);
       delete this;
@@ -199,14 +199,14 @@ syslogng::grpc::otel::LogsServiceCall::Proceed(bool ok)
   if (msgs_in_fetch_round != 0)
     log_threaded_source_worker_close_batch(&worker.super->super);
 
-  status = FINISH;
+  status = SEND_RESPONSE;
   responder.Finish(response, response_status, this);
 }
 
 template <> void
 syslogng::grpc::otel::MetricsServiceCall::Proceed(bool ok)
 {
-  if (status == FINISH || !ok)
+  if (status == SEND_RESPONSE || !ok)
     {
       new MetricsServiceCall(worker, service, cq);
       delete this;
@@ -256,7 +256,7 @@ syslogng::grpc::otel::MetricsServiceCall::Proceed(bool ok)
   if (msgs_in_fetch_round != 0)
     log_threaded_source_worker_close_batch(&worker.super->super);
 
-  status = FINISH;
+  status = SEND_RESPONSE;
   responder.Finish(response, response_status, this);
 }
 

--- a/modules/grpc/otel/otel-source-services.hpp
+++ b/modules/grpc/otel/otel-source-services.hpp
@@ -86,11 +86,10 @@ syslogng::grpc::otel::TraceServiceCall::Proceed(bool ok)
 {
   if (status == FINISH || !ok)
     {
+      new TraceServiceCall(worker, service, cq);
       delete this;
       return;
     }
-
-  new TraceServiceCall(worker, service, cq);
 
   ::grpc::Status response_status = ::grpc::Status::OK;
 
@@ -144,11 +143,10 @@ syslogng::grpc::otel::LogsServiceCall::Proceed(bool ok)
 {
   if (status == FINISH || !ok)
     {
+      new LogsServiceCall(worker, service, cq);
       delete this;
       return;
     }
-
-  new LogsServiceCall(worker, service, cq);
 
   ::grpc::Status response_status = ::grpc::Status::OK;
 
@@ -210,11 +208,10 @@ syslogng::grpc::otel::MetricsServiceCall::Proceed(bool ok)
 {
   if (status == FINISH || !ok)
     {
+      new MetricsServiceCall(worker, service, cq);
       delete this;
       return;
     }
-
-  new MetricsServiceCall(worker, service, cq);
 
   ::grpc::Status response_status = ::grpc::Status::OK;
 

--- a/modules/grpc/otel/syslog-ng-otlp-dest-worker.cpp
+++ b/modules/grpc/otel/syslog-ng-otlp-dest-worker.cpp
@@ -28,14 +28,14 @@ using namespace opentelemetry::proto::logs::v1;
 ScopeLogs *
 SyslogNgDestWorker::lookup_scope_logs(LogMessage *msg)
 {
-  if (logs_service_request.resource_logs_size() > 0)
-    return logs_service_request.mutable_resource_logs(0)->mutable_scope_logs(0);
+  if (logs_service_request->resource_logs_size() > 0)
+    return logs_service_request->mutable_resource_logs(0)->mutable_scope_logs(0);
 
   clear_current_msg_metadata();
   formatter.get_metadata_for_syslog_ng(current_msg_metadata.resource, current_msg_metadata.resource_schema_url,
                                        current_msg_metadata.scope, current_msg_metadata.scope_schema_url);
 
-  ResourceLogs *resource_logs = logs_service_request.add_resource_logs();
+  ResourceLogs *resource_logs = logs_service_request->add_resource_logs();
   resource_logs->mutable_resource()->CopyFrom(current_msg_metadata.resource);
   resource_logs->set_schema_url(current_msg_metadata.resource_schema_url);
 

--- a/modules/grpc/pubsub/pubsub-dest-worker.cpp
+++ b/modules/grpc/pubsub/pubsub-dest-worker.cpp
@@ -61,7 +61,9 @@ DestWorker::connect()
 }
 
 DestWorker::DestWorker(GrpcDestWorker *s)
-  : syslogng::grpc::DestWorker(s)
+  : syslogng::grpc::DestWorker(s),
+    request(arena.CreateMessage<::google::pubsub::v1::PublishRequest>()),
+    response(arena.CreateMessage<::google::pubsub::v1::PublishResponse>())
 {
 }
 
@@ -166,7 +168,7 @@ DestWorker::insert(LogMessage *msg)
 
   size_t message_bytes = 0;
 
-  ::google::pubsub::v1::PubsubMessage *message = this->request.add_messages();
+  ::google::pubsub::v1::PubsubMessage *message = this->request->add_messages();
 
   if (owner_->proto_var)
     {
@@ -186,11 +188,11 @@ DestWorker::insert(LogMessage *msg)
     {
       this->client_context = std::make_unique<::grpc::ClientContext>();
       prepare_context_dynamic(*this->client_context, msg);
-      this->request.set_topic(this->format_topic(msg));
+      this->request->set_topic(this->format_topic(msg));
     }
 
   msg_trace("Message added to Google Pub/Sub batch",
-            evt_tag_str("project/topic", this->request.topic().c_str()),
+            evt_tag_str("project/topic", this->request->topic().c_str()),
             log_pipe_location_tag(&this->super->super.owner->super.super.super));
 
   if (this->should_initiate_flush())
@@ -251,11 +253,14 @@ permanent_error:
 void
 DestWorker::prepare_batch()
 {
-  this->request.clear_topic();
-  this->request.clear_messages();
+  this->client_context.reset();
+
+  this->arena.Reset();
+  this->request = arena.CreateMessage<::google::pubsub::v1::PublishRequest>();
+  this->response = arena.CreateMessage<::google::pubsub::v1::PublishResponse>();
+
   this->batch_size = 0;
   this->current_batch_bytes = 0;
-  this->client_context.reset();
 }
 
 LogThreadedResult
@@ -264,9 +269,7 @@ DestWorker::flush(LogThreadedFlushMode mode)
   if (this->batch_size == 0)
     return LTR_SUCCESS;
 
-  ::google::pubsub::v1::PublishResponse response;
-
-  ::grpc::Status status = this->stub->Publish(this->client_context.get(), this->request, &response);
+  ::grpc::Status status = this->stub->Publish(this->client_context.get(), *this->request, this->response);
 
   LogThreadedResult result;
   if (!owner.handle_response(status, &result))
@@ -279,7 +282,7 @@ DestWorker::flush(LogThreadedFlushMode mode)
   log_threaded_dest_driver_insert_batch_length_stats(this->super->super.owner, this->current_batch_bytes);
 
   msg_debug("Google Pub/Sub batch delivered",
-            evt_tag_str("project/topic", this->request.topic().c_str()),
+            evt_tag_str("project/topic", this->request->topic().c_str()),
             log_pipe_location_tag(&this->super->super.owner->super.super.super));
 
 exit:

--- a/modules/grpc/pubsub/pubsub-dest-worker.hpp
+++ b/modules/grpc/pubsub/pubsub-dest-worker.hpp
@@ -65,7 +65,8 @@ private:
   std::unique_ptr<::google::pubsub::v1::Publisher::Stub> stub;
   std::unique_ptr<::grpc::ClientContext> client_context;
 
-  ::google::pubsub::v1::PublishRequest request;
+  ::google::pubsub::v1::PublishRequest *request;
+  ::google::pubsub::v1::PublishResponse *response;
   size_t batch_size = 0;
   size_t current_batch_bytes = 0;
 

--- a/news/other-1015.md
+++ b/news/other-1015.md
@@ -1,0 +1,1 @@
+otlp-destination: improve performance by using gRPC arenas for allocation


### PR DESCRIPTION
This is done in order to make sure that new ServiceCall objects
are only created once their predecessor's destructor is called.

Signed-off-by: Szilard Parrag <szilard.parrag@axoflow.com><!--
Thank you for contributing to AxoSyslog. Please make sure you:
- Read our Contribution guideline: https://github.com/axoflow/axosyslog/blob/main/CONTRIBUTING.md
- Checked that tests pass (including stylechecks: `make style-check`)
- Wrote a news file, if applicable: https://github.com/axoflow/axosyslog/tree/main/news
-->


<!--
PR description
In the description, please explain the problem your pull request intends to solve, and a give general overview of the implementation.
For more information, see: https://github.com/axoflow/axosyslog/blob/main/CONTRIBUTING.md#pr-description
-->
